### PR TITLE
Front: 라우터 수정, 리그 페이지 carousel 추가

### DIFF
--- a/final-pjt-front/src/App.vue
+++ b/final-pjt-front/src/App.vue
@@ -17,11 +17,11 @@
 
       <nav class="navbar shrink mt-1 hidden-sm-and-down">
         <router-link to="/">
-          <v-btn depressed>Home</v-btn>
+          <v-btn depressed>League</v-btn>
         </router-link>
 
-        <router-link to="/league">
-          <v-btn depressed>League</v-btn>
+        <router-link to="/ranking">
+          <v-btn depressed>Ranking</v-btn>
         </router-link>
         
         <router-link to="/mypage">

--- a/final-pjt-front/src/components/LeagueList.vue
+++ b/final-pjt-front/src/components/LeagueList.vue
@@ -1,26 +1,44 @@
 <template>
-<div>
-  <h2>Movie League</h2>
-  <v-btn @click.prevent="goMatchCreate()">
-    <v-icon>mdi-fencing</v-icon>매치 만들기 <v-icon>mdi-fencing</v-icon>
-  </v-btn>
-  <div class="container">
-    <!-- <CreateMatch/> -->
+  <div>
+    <h2>Movie League</h2>
+    <v-btn @click.prevent="goMatchCreate()">
+      <v-icon>mdi-fencing</v-icon>매치 만들기 <v-icon>mdi-fencing</v-icon>
+    </v-btn>
     <hr>
-      <LeagueListItem
-        v-for="match in matches"
-        :key="match.id"
-        :match="match"/>
+    <v-carousel v-model="model">
+      <v-carousel-item v-for="(match, i) in matches" :key="match.pk">
+        <v-sheet :color="color" height="100%" tile>
+          <v-row class="fill-height" align="center" justify="center">
+            {{ i + 1 }}번째 매치
+            <LeagueListItem :match="match" />
+          </v-row>
+        </v-sheet>
+      </v-carousel-item>
+    </v-carousel>
+
+    <!-- <v-container>
+      <LeagueListItem v-for="match in matches" :key="match.id" :match="match" />
+    </v-container> -->
   </div>
-</div>
 </template>
 
 <script>
-import LeagueListItem from '@/components/LeagueListItem'
+import LeagueListItem from "@/components/LeagueListItem";
 // import CreateMatch from '@/components/CreateMatch'
 
 export default {
-  name: 'LeagueList',
+  name: "LeagueList",
+  data() {
+    return {
+      model: 0,
+      colors: [
+        "primary", 
+        "secondary", 
+        "yellow darken-2", 
+        "red", 
+        "orange"],
+    };
+  },
   components: {
     LeagueListItem,
     // CreateMatch,
@@ -28,13 +46,13 @@ export default {
   computed: {
     matches() {
       // console.log(this.$store.state.movies)
-      return this.$store.state.matches
-    }
+      return this.$store.state.matches;
+    },
   },
   methods: {
     goMatchCreate() {
-      this.$router.push({ name: 'CreateMatch' })
+      this.$router.push({ name: "CreateMatch" });
     },
   },
-}
+};
 </script>

--- a/final-pjt-front/src/components/LeagueListItem.vue
+++ b/final-pjt-front/src/components/LeagueListItem.vue
@@ -1,11 +1,18 @@
 <template>
   <div @click.stop="goMatchDetail(match.pk, match.movie_1, match.movie_2)">
-    <!-- <h4>{{ match }}</h4> -->
-    <br />
-    <img :src="firstPoster" alt="IMG" style="width: 30%; height: 43%" />
-    <img :src="secPoster" alt="IMG" style="width: 30%; height: 43%" />
-    <br />
-    <h4>{{ firstMovie.title }} vs {{ secMovie.title }}</h4>
+    <v-row rows="auto">
+      <v-col class="row justify-content-center">
+        <v-card class="px-0 py-0 m-3" max-width="300">
+          <v-img :src="firstPoster" alt="IMG" :aspect-ratio="1 / 1.414" />
+        </v-card>
+        <v-card class="px-0 py-0 m-3" max-width="300">
+          <v-img :src="secPoster" alt="IMG" :aspect-ratio="1 / 1.414" />
+        </v-card>
+      </v-col>
+      <!-- <v-col class="row justify-content-center">
+      </v-col> -->
+      <h4>{{ firstMovie.title }} vs {{ secMovie.title }}</h4>
+    </v-row>
     <hr />
   </div>
 </template>

--- a/final-pjt-front/src/components/MovieListItem.vue
+++ b/final-pjt-front/src/components/MovieListItem.vue
@@ -4,7 +4,7 @@
     class="px-0 py-0"
     max-width="400"
   >
-    <v-img :src="poster" alt="IMG" :aspect-ratio="1/1.414"/>
+    <v-img :src="poster" alt="IMG" :aspect-ratio="1 / 1.414" />
   </v-card>
   <!-- <div @click.stop="goDetail(movie.movie_id)">
     <div class="flip-card">

--- a/final-pjt-front/src/router/index.js
+++ b/final-pjt-front/src/router/index.js
@@ -11,7 +11,7 @@ Vue.use(VueRouter)
 
 const routes = [
   {
-    path: '/',
+    path: '/ranking',
     name: 'HomeView',
     component: HomeView,
   },
@@ -21,7 +21,7 @@ const routes = [
     component: () => import('../components/MovieDetail.vue')
   },
   {
-    path: '/league/',
+    path: '/',
     name: 'LeagueView',
     component: () => import(/* webpackChunkName: "about" */ '../views/LeagueView.vue'),
     // 자식 라우터로 넣고 싶다면..


### PR DESCRIPTION
1. 라우터 수정
- 리그 페이지가 메인 화면에 나오도록 수정
2. 리그 페이지에 carousel 추가
- 처음 3개만 carousel에 나오고 나머지는 하단에 리스트로 나오도록 수정 필요